### PR TITLE
Corrige errores reportados en Issue #188 y #189

### DIFF
--- a/Maps/TMA Cancun/MMUN_RWYS12.xml
+++ b/Maps/TMA Cancun/MMUN_RWYS12.xml
@@ -3,7 +3,7 @@
   <Map Type="System" Name="MMUN - Pistas 12 - Llegadas RNAV" Priority="1" Center="+210235.014-0865232.438">
     <!--STARs-->
     <Line Name="ILUBA1E" Pattern="Dashed">ILUBA/URVEN/UN524/UN523/UN511/UN519/UN514/ELINO/EBMIS</Line>
-    <Line Name="PUALE1G" Pattern="Dashed">PAULE/CZM/UN518/UN511</Line>
+    <Line Name="PAULE1G" Pattern="Dashed">PAULE/CZM/UN518/UN511</Line>
     <Line Name="SIGMA1G" Pattern="Dashed">SIGMA/HURIN/UN523</Line>
     <Line Name="NOSAT1B" Pattern="Dashed">NOSAT/HACHO/LETIS/APMUS/UN500/UN522/UN515/ERDAM/RIDUG</Line>
     <Line Name="VOMAR1A" Pattern="Dashed">VOMAR/AGNIX/EPNEL/ODLAR/VIKSI</Line>
@@ -216,7 +216,6 @@
       <Point>ROTGI</Point>
       <Point>SEVKA</Point>
       <Point>TAKUX</Point>
-      <Point>UDGUV</Point>
       <Point>ULBOX</Point>
       <Point>UN400</Point>
       <Point>UN402</Point>

--- a/Positions.xml
+++ b/Positions.xml
@@ -612,13 +612,13 @@
         <Map Name="Universal/Geografia - Linea de Costa" />
       </Maps>
       <Strips Mode="Beacon" Sort="Alpha">
-        <Window Type="ADEP" Beacon="MMSD" Visible="true" />
+        <Window Type="ADEP" Beacon="MMSL" Visible="true" />
       </Strips>
       <CFL QuickLevel="1200">
         <AdditionalLevels>7400,3200,2400</AdditionalLevels>
       </CFL>
       <ArrivalLists>
-        <Airport Name="MMSD" />
+        <Airport Name="MMSL" />
       </ArrivalLists>
       <ControllerInfo>
         <Line>>Torre San Lucas / San Lucas Tower</Line>


### PR DESCRIPTION
Procedimiento PAULE1G estaba originalmente mal escrito;
 El fijo UDGUV estaba representado como fijo RNAV (HollowStar) y Fijo convencional (SolidTriangle) a la vez cuando solo tenia que estar como Fijo convencional (SolidTriangle);
Corrige listas ADEP y Arrival list de MMSL.