### PR TITLE
Changes Double Fix Representation

### DIFF
--- a/Maps/TMA Cancun/MMUN_RWYS12.xml
+++ b/Maps/TMA Cancun/MMUN_RWYS12.xml
@@ -216,7 +216,6 @@
             <Point>ROTGI</Point>
             <Point>SEVKA</Point>
             <Point>TAKUX</Point>
-            <Point>UDGUV</Point>
             <Point>ULBOX</Point>
             <Point>UN400</Point>
             <Point>UN402</Point>


### PR DESCRIPTION
-UDGUV Fix was represented both by a Hollow Star and a Solid Triangle (only in RWYS 12 diagram), left solid triangle (DME FIX)