### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,14 +8,14 @@ jobs:
   zip-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - name: Archive Release
-      uses: thedoctor0/zip-release@master
+      uses: thedoctor0/zip-release@0.7.6
       with:
         filename: 'profile.zip'
         exclusions: '*.git* /*node_modules/* .editorconfig *.md'
     - name: FTP-Deploy-Action
-      uses: SamKirkland/FTP-Deploy-Action@4.3.0
+      uses: SamKirkland/FTP-Deploy-Action@v4.3.6
       with:
         server: ftp.sawbe.com
         server-dir: mexico-dark/


### PR DESCRIPTION
Updates release workflow actions only:

- actions/checkout@master -> actions/checkout@v4
- thedoctor0/zip-release@master -> thedoctor0/zip-release@0.7.6
- SamKirkland/FTP-Deploy-Action@4.3.0 -> SamKirkland/FTP-Deploy-Action@v4.3.6

This addresses the GitHub Actions Node.js 20 deprecation warning without changing release contents.